### PR TITLE
fix: corrige reatividade das props de texto ao exibir validações salvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sysvale/form-builder",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "type": "module",
   "main": "dist/form-builder.umd.js",

--- a/resources/components/FormBuilder.vue
+++ b/resources/components/FormBuilder.vue
@@ -187,7 +187,7 @@
 									v-bind="field"
 									:is="field.editor"
 									:label="field.label"
-									:model-value="selectedElement.rules"
+									v-model="field.modelValue"
 									@update:model-value="handleRulesUpdate(field, $event)"
 									fluid
 									ref="inputRefs2"

--- a/resources/shared/constants/validationTypes.js
+++ b/resources/shared/constants/validationTypes.js
@@ -42,6 +42,7 @@ export const validationTypes = {
 	alpha: {
 		type: 'string',
 		editor: 'CdsSelect',
+		modelValue: null,
 		options: [
 			{
 				label: 'alpha',
@@ -66,27 +67,6 @@ export const validationTypes = {
 		],
 		defaultValue: 'false',
 		label: 'Tipo de validação',
-		description: 'Texto exibido acima do campo'
-	},
-	alpha_num: {
-		type: 'string',
-		editor: 'CdsTextInput',
-		defaultValue: '',
-		label: 'alpha_num',
-		description: 'Texto exibido acima do campo'
-	},
-	alpha_spaces: {
-		type: 'string',
-		editor: 'CdsTextInput',
-		defaultValue: '',
-		label: 'alpha_spaces',
-		description: 'Texto exibido acima do campo'
-	},
-	alpha_dash: {
-		type: 'string',
-		editor: 'CdsTextInput',
-		defaultValue: '',
-		label: 'alpha_dash',
 		description: 'Texto exibido acima do campo'
 	},
 };


### PR DESCRIPTION
Os campos de configuração (como "alpha", "alpha_spaces", etc.) aplicavam corretamente as regras, mas ao reabrir as configurações, o select não exibia a regra previamente selecionada.